### PR TITLE
Define Paxos protos

### DIFF
--- a/diypaxos/server/BUILD
+++ b/diypaxos/server/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "server",
-    srcs = ["server.go"],
+    srcs = [
+        "consensushandlers.go",
+        "server.go",
+    ],
     importpath = "diy-paxos/diypaxos/server",
     visibility = ["//visibility:public"],
     deps = [

--- a/diypaxos/server/consensushandlers.go
+++ b/diypaxos/server/consensushandlers.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"context"
+	pb "diy-paxos/diypaxos/proto"
+)
+
+func (s *Server) Promise(ctx context.Context, in *pb.PromiseRequest) (*pb.PromiseResponse, error) {
+	return nil, nil
+}
+
+func (s *Server) Accept(ctx context.Context, in *pb.AcceptRequest) (*pb.AcceptResponse, error) {
+	return nil, nil
+}

--- a/diypaxos/server/server.go
+++ b/diypaxos/server/server.go
@@ -19,6 +19,8 @@ type KvStoreServer interface {
 	Remove(ctx context.Context, in *pb.RemoveRequest) (*pb.RemoveResponse, error)
 	Update(ctx context.Context, in *pb.UpdateRequest) (*pb.UpdateResponse, error)
 	Upsert(ctx context.Context, in *pb.UpsertRequest) (*pb.UpsertResponse, error)
+	Accept(ctx context.Context, in *pb.AcceptRequest) (*pb.AcceptResponse, error)
+	Promise(ctx context.Context, in *pb.PromiseRequest) (*pb.PromiseResponse, error)
 }
 
 // Server implements the SimpleKvStore Server.

--- a/diypaxos/storage/inmemorystorage.go
+++ b/diypaxos/storage/inmemorystorage.go
@@ -5,6 +5,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type Metadata struct {
+	Version int32
+}
+
+type Value struct {
+	Value int32
+	Meta  Metadata
+}
+
 // Storage exposes an API to interface with a KV Storage container.
 type Storage interface {
 	Insert(k string, v int32) error
@@ -16,12 +25,12 @@ type Storage interface {
 
 // InMemoryStorage implements Storage with an in-memory table.
 type InMemoryStorage struct {
-	store map[string]int32
+	store map[string]Value
 }
 
 // NewInMemoryStorage creates a new InMemoryStorage instance.
 func NewInMemoryStorage() Storage {
-	return &InMemoryStorage{map[string]int32{}}
+	return &InMemoryStorage{map[string]Value{}}
 }
 
 // Insert inserts a KV pair into the Storage container.
@@ -29,7 +38,7 @@ func (i *InMemoryStorage) Insert(k string, v int32) error {
 	if _, exists := i.store[k]; exists {
 		return status.New(codes.AlreadyExists, "cannot insert to an already populated key").Err()
 	}
-	i.store[k] = v
+	i.store[k] = Value{Value: v}
 	return nil
 }
 
@@ -38,7 +47,7 @@ func (i *InMemoryStorage) Get(k string) (int32, error) {
 	if _, exists := i.store[k]; !exists {
 		return -1, status.New(codes.NotFound, "cannot get non existent key").Err()
 	}
-	return i.store[k], nil
+	return i.store[k].Value, nil
 }
 
 // Remove deletes a value by key from a storage container.
@@ -55,7 +64,7 @@ func (i *InMemoryStorage) Update(k string, v int32) error {
 	if _, exists := i.store[k]; !exists {
 		return status.New(codes.NotFound, "cannot update a non existent key").Err()
 	}
-	i.store[k] = v
+	i.store[k] = Value{Value: v}
 	return nil
 }
 

--- a/diypaxos/storage/inmemorystorage_test.go
+++ b/diypaxos/storage/inmemorystorage_test.go
@@ -6,7 +6,7 @@ type FakeKvStoreServer struct {
 	InMemoryStorage
 }
 
-func (s *FakeKvStoreServer) setStore(store map[string]int32) {
+func (s *FakeKvStoreServer) setStore(store map[string]Value) {
 	s.store = store
 }
 
@@ -15,19 +15,19 @@ func TestInsert(t *testing.T) {
 		name    string
 		key     string
 		val     int
-		store   map[string]int32
+		store   map[string]Value
 		wantErr bool
 	}{
 		{
 			name:  "Insert new",
 			key:   "new",
 			val:   1,
-			store: map[string]int32{},
+			store: map[string]Value{},
 		}, {
 			name:    "Insert existing",
 			key:     "exist",
 			val:     1,
-			store:   map[string]int32{"exist": 1},
+			store:   map[string]Value{"exist": Value{Value: 1}},
 			wantErr: true,
 		},
 	} {
@@ -46,19 +46,19 @@ func TestGet(t *testing.T) {
 		name    string
 		key     string
 		val     int
-		store   map[string]int32
+		store   map[string]Value
 		wantErr bool
 	}{
 		{
 			name:    "Get DNE",
 			key:     "new",
 			wantErr: true,
-			store:   map[string]int32{},
+			store:   map[string]Value{},
 		}, {
 			name:  "Get Existing",
 			key:   "exist",
 			val:   1,
-			store: map[string]int32{"exist": 1},
+			store: map[string]Value{"exist": Value{Value: 1}},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -77,18 +77,18 @@ func TestRemove(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		key     string
-		store   map[string]int32
+		store   map[string]Value
 		wantErr bool
 	}{
 		{
 			name:    "Remove DNE",
 			key:     "dne",
-			store:   map[string]int32{},
+			store:   map[string]Value{},
 			wantErr: true,
 		}, {
 			name:  "Remove Existing",
 			key:   "exist",
-			store: map[string]int32{"exist": 1},
+			store: map[string]Value{"exist": Value{Value: 1}},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -113,19 +113,19 @@ func TestUpdate(t *testing.T) {
 		name    string
 		key     string
 		new     int
-		store   map[string]int32
+		store   map[string]Value
 		wantErr bool
 	}{
 		{
 			name:    "Update DNE",
 			key:     "dne",
-			store:   map[string]int32{},
+			store:   map[string]Value{},
 			wantErr: true,
 		}, {
 			name:  "Update Existing",
 			key:   "exist",
 			new:   2,
-			store: map[string]int32{"exist": 1},
+			store: map[string]Value{"exist": Value{Value: 1}},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestUpdate(t *testing.T) {
 			if tc.wantErr {
 				return
 			}
-			if val, _ := tc.store[tc.key]; val != int32(tc.new) {
+			if val, _ := tc.store[tc.key]; val.Value != int32(tc.new) {
 				t.Errorf("got %v, want %v", val, tc.new)
 			}
 		})
@@ -149,18 +149,18 @@ func TestUpsert(t *testing.T) {
 		name    string
 		key     string
 		new     int
-		store   map[string]int32
+		store   map[string]Value
 		wantErr bool
 	}{
 		{
 			name:  "Update DNE",
 			key:   "dne",
-			store: map[string]int32{},
+			store: map[string]Value{},
 		}, {
 			name:  "Update Existing",
 			key:   "exist",
 			new:   2,
-			store: map[string]int32{"exist": 1},
+			store: map[string]Value{"exist": {Value: 1}},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestUpsert(t *testing.T) {
 			if tc.wantErr {
 				return
 			}
-			if val, _ := tc.store[tc.key]; val != int32(tc.new) {
+			if val, _ := tc.store[tc.key]; val.Value != int32(tc.new) {
 				t.Errorf("got %v, want %v", val, tc.new)
 			}
 		})


### PR DESCRIPTION
In this PR, we define the protos that will be used for Paxos.

We also make a couple of tweaks to support versioning in our in-memory KVStore impl.